### PR TITLE
Decompose ExperimentConfig into typed sub-configs

### DIFF
--- a/configs/experiments/data_proportions/mix_baseline.yaml
+++ b/configs/experiments/data_proportions/mix_baseline.yaml
@@ -10,45 +10,41 @@
 
 name: mix-baseline
 description: Data proportions experiment - balanced baseline mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings - use 14M model for fast tests
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings - fixed at 0.5x Chinchilla for all proportion experiments
-chinchilla_multiple: 0.5  # 0.5 * 20 * 14M = 140M tokens
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Data sources - balanced mix (control)
-# Proportions: ~20% each domain (equal weighting)
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: dclm
     max_repetition_factor: 1.0
     topics:
-      - name: science_math_and_technology
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy"
-      - name: software_development
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy"
-      - name: education_and_jobs
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy"
-
+    - name: science_math_and_technology
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy
+    - name: software_development
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy
+    - name: education_and_jobs
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy
   - name: wikipedia
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
-
   - name: arxiv
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
+swarm:
+  seed: 42
+  variants: 1

--- a/configs/experiments/data_proportions/mix_heavy_code.yaml
+++ b/configs/experiments/data_proportions/mix_heavy_code.yaml
@@ -15,50 +15,46 @@
 
 name: mix-heavy-code
 description: Data proportions experiment - 50% code emphasis
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings - use 14M model for fast tests
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings - fixed at 0.5x Chinchilla for all proportion experiments
-chinchilla_multiple: 0.5  # 0.5 * 20 * 14M = 140M tokens
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Data sources - code-heavy mix
-# Target: 50% code, 20% science, 10% education, 10% wiki, 10% arxiv
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/saturn
+  priority: urgent
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: dclm
     max_repetition_factor: 1.0
     topics:
-      - name: software_development
-        weight: 5.0  # 50% - primary emphasis
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy"
-      - name: science_math_and_technology
-        weight: 2.0  # 20%
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy"
-      - name: education_and_jobs
-        weight: 1.0  # 10%
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy"
-
+    - name: software_development
+      weight: 5.0
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy
+    - name: science_math_and_technology
+      weight: 2.0
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy
+    - name: education_and_jobs
+      weight: 1.0
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy
   - name: wikipedia
-    weight: 1.0  # 10%
+    weight: 1.0
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
-
   - name: arxiv
-    weight: 1.0  # 10%
+    weight: 1.0
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
+swarm:
+  seed: 42
+  variants: 1

--- a/configs/experiments/data_proportions/mix_heavy_science.yaml
+++ b/configs/experiments/data_proportions/mix_heavy_science.yaml
@@ -15,50 +15,46 @@
 
 name: mix-heavy-science
 description: Data proportions experiment - 50% science emphasis
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings - use 14M model for fast tests
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings - fixed at 0.5x Chinchilla for all proportion experiments
-chinchilla_multiple: 0.5  # 0.5 * 20 * 14M = 140M tokens
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Data sources - science-heavy mix
-# Target: 50% science, 10% code, 10% education, 10% wiki, 20% arxiv
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: dclm
     max_repetition_factor: 1.0
     topics:
-      - name: science_math_and_technology
-        weight: 5.0  # 50% - primary emphasis
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy"
-      - name: software_development
-        weight: 1.0  # 10%
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy"
-      - name: education_and_jobs
-        weight: 1.0  # 10%
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy"
-
+    - name: science_math_and_technology
+      weight: 5.0
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy
+    - name: software_development
+      weight: 1.0
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy
+    - name: education_and_jobs
+      weight: 1.0
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy
   - name: wikipedia
-    weight: 1.0  # 10%
+    weight: 1.0
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
-
   - name: arxiv
-    weight: 2.0  # 20% - complementary to science
+    weight: 2.0
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
+swarm:
+  seed: 42
+  variants: 1

--- a/configs/experiments/data_proportions/mix_heavy_wiki.yaml
+++ b/configs/experiments/data_proportions/mix_heavy_wiki.yaml
@@ -15,50 +15,46 @@
 
 name: mix-heavy-wiki
 description: Data proportions experiment - 50% wikipedia emphasis
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings - use 14M model for fast tests
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings - fixed at 0.5x Chinchilla for all proportion experiments
-chinchilla_multiple: 0.5  # 0.5 * 20 * 14M = 140M tokens
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Data sources - wikipedia-heavy mix
-# Target: 50% wiki, 15% science, 15% code, 10% education, 10% arxiv
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: dclm
     max_repetition_factor: 1.0
     topics:
-      - name: science_math_and_technology
-        weight: 1.5  # 15%
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy"
-      - name: software_development
-        weight: 1.5  # 15%
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy"
-      - name: education_and_jobs
-        weight: 1.0  # 10%
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy"
-
+    - name: science_math_and_technology
+      weight: 1.5
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy
+    - name: software_development
+      weight: 1.5
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy
+    - name: education_and_jobs
+      weight: 1.0
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy
   - name: wikipedia
-    weight: 5.0  # 50% - primary emphasis
+    weight: 5.0
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
-
   - name: arxiv
-    weight: 1.0  # 10%
+    weight: 1.0
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
+swarm:
+  seed: 42
+  variants: 1

--- a/configs/experiments/quality_thresholds/heavy_adult/top10pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_adult/top10pct.yaml
@@ -11,82 +11,89 @@
 
 name: quality-top10pct-heavy-adult
 description: Quality experiment - top10pct with heavy adult mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 15
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 15
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 10
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 50
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 15
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 15
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 10
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 50
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_adult/top30pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_adult/top30pct.yaml
@@ -11,118 +11,143 @@
 
 name: quality-top30pct-heavy-adult
 description: Quality experiment - top30pct with heavy adult mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 15
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 15
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 10
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 50
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 15
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 15
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 10
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 50
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_adult/top50pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_adult/top50pct.yaml
@@ -11,166 +11,215 @@
 
 name: quality-top50pct-heavy-adult
 description: Quality experiment - top50pct with heavy adult mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 15
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 15
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 10
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 50
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 15
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 15
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 10
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 50
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_adult/top70pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_adult/top70pct.yaml
@@ -11,214 +11,287 @@
 
 name: quality-top70pct-heavy-adult
 description: Quality experiment - top70pct with heavy adult mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 15
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 15
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 10
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 50
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 15
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 15
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 10
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 50
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_code/top10pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_code/top10pct.yaml
@@ -11,82 +11,89 @@
 
 name: quality-top10pct-heavy-code
 description: Quality experiment - top10pct with heavy code mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 20
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 50
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 20
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 50
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_code/top30pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_code/top30pct.yaml
@@ -11,118 +11,143 @@
 
 name: quality-top30pct-heavy-code
 description: Quality experiment - top30pct with heavy code mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 20
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 50
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 20
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 50
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_code/top50pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_code/top50pct.yaml
@@ -11,166 +11,215 @@
 
 name: quality-top50pct-heavy-code
 description: Quality experiment - top50pct with heavy code mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 20
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 50
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 20
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 50
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_code/top70pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_code/top70pct.yaml
@@ -11,214 +11,287 @@
 
 name: quality-top70pct-heavy-code
 description: Quality experiment - top70pct with heavy code mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 20
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 50
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 20
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 50
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_science/top10pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_science/top10pct.yaml
@@ -11,82 +11,89 @@
 
 name: quality-top10pct-heavy-science
 description: Quality experiment - top10pct with heavy science mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 50
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 50
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_science/top30pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_science/top30pct.yaml
@@ -11,118 +11,143 @@
 
 name: quality-top30pct-heavy-science
 description: Quality experiment - top30pct with heavy science mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 50
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 50
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_science/top50pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_science/top50pct.yaml
@@ -11,166 +11,215 @@
 
 name: quality-top50pct-heavy-science
 description: Quality experiment - top50pct with heavy science mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 50
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 50
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_science/top70pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_science/top70pct.yaml
@@ -11,214 +11,287 @@
 
 name: quality-top70pct-heavy-science
 description: Quality experiment - top70pct with heavy science mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 98
     topics:
-      - name: science_math_and_technology
-        weight: 50
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 5
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 3
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 50
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_wiki/top10pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_wiki/top10pct.yaml
@@ -11,82 +11,89 @@
 
 name: quality-top10pct-heavy-wiki
 description: Quality experiment - top10pct with heavy wiki mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 69
     topics:
-      - name: science_math_and_technology
-        weight: 25
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 1
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 25
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 1
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 30
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_wiki/top30pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_wiki/top30pct.yaml
@@ -11,118 +11,143 @@
 
 name: quality-top30pct-heavy-wiki
 description: Quality experiment - top30pct with heavy wiki mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 69
     topics:
-      - name: science_math_and_technology
-        weight: 25
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 1
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 25
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 1
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 30
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_wiki/top50pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_wiki/top50pct.yaml
@@ -11,166 +11,215 @@
 
 name: quality-top50pct-heavy-wiki
 description: Quality experiment - top50pct with heavy wiki mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 69
     topics:
-      - name: science_math_and_technology
-        weight: 25
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 1
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 25
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 1
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 30
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_thresholds/heavy_wiki/top70pct.yaml
+++ b/configs/experiments/quality_thresholds/heavy_wiki/top70pct.yaml
@@ -11,214 +11,287 @@
 
 name: quality-top70pct-heavy-wiki
 description: Quality experiment - top70pct with heavy wiki mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Lower minimum weight to prevent quality buckets from being clipped
-minimum_weight: 0.0001
-
-# Data sources with fixed topic weights
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: all_dressed
     weight: 69
     topics:
-      - name: science_math_and_technology
-        weight: 25
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy"]
-      - name: software_development
-        weight: 20
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy"]
-      - name: education_and_jobs
-        weight: 15
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy"]
-      - name: politics
-        weight: 3
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy"]
-      - name: adult_content
-        weight: 1
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy"]
-      - name: art_and_design
-        weight: 5
-        quality:
-          - name: vigintile_0007
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy"]
-          - name: vigintile_0008
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy"]
-          - name: vigintile_0009
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy"]
-          - name: vigintile_0010
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy"]
-          - name: vigintile_0011
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy"]
-          - name: vigintile_0012
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy"]
-          - name: vigintile_0013
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy"]
-          - name: vigintile_0014
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy"]
-          - name: vigintile_0015
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy"]
-          - name: vigintile_0016
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy"]
-          - name: vigintile_0017
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy"]
-          - name: vigintile_0018
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy"]
-          - name: vigintile_0020
-            paths: ["s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy"]
-
+    - name: science_math_and_technology
+      weight: 25
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+    - name: adult_content
+      weight: 1
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: vigintile_0007
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0007/*.npy
+      - name: vigintile_0008
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0008/*.npy
+      - name: vigintile_0009
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0009/*.npy
+      - name: vigintile_0010
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0010/*.npy
+      - name: vigintile_0011
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0011/*.npy
+      - name: vigintile_0012
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0012/*.npy
+      - name: vigintile_0013
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0013/*.npy
+      - name: vigintile_0014
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0014/*.npy
+      - name: vigintile_0015
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+      - name: vigintile_0016
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: vigintile_0017
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+      - name: vigintile_0018
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: vigintile_0020
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
   - name: arxiv
     weight: 1
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
-
   - name: wikipedia
     weight: 30
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_adult/aggressive.yaml
+++ b/configs/experiments/quality_upsampling/heavy_adult/aggressive.yaml
@@ -10,132 +10,137 @@
 
 name: quality-upsampling-aggressive-heavy-adult
 description: Quality upsampling experiment - aggressive weighting with heavy adult mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 98
-  topics:
-  - name: science_math_and_technology
-    weight: 15
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-  - name: software_development
-    weight: 15
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-  - name: education_and_jobs
-    weight: 10
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-  - name: politics
-    weight: 3
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-  - name: adult_content
-    weight: 50
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 98
+    topics:
+    - name: science_math_and_technology
+      weight: 15
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+    - name: software_development
+      weight: 15
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+    - name: education_and_jobs
+      weight: 10
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+    - name: adult_content
+      weight: 50
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+  - name: arxiv
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_adult/gradual.yaml
+++ b/configs/experiments/quality_upsampling/heavy_adult/gradual.yaml
@@ -10,150 +10,155 @@
 
 name: quality-upsampling-gradual-heavy-adult
 description: Quality upsampling experiment - gradual weighting with heavy adult mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 98
-  topics:
-  - name: science_math_and_technology
-    weight: 15
-    quality:
-    - name: best
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 98
+    topics:
+    - name: science_math_and_technology
+      weight: 15
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+    - name: software_development
+      weight: 15
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+    - name: education_and_jobs
+      weight: 10
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+    - name: adult_content
       weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-  - name: software_development
-    weight: 15
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-  - name: education_and_jobs
-    weight: 10
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-  - name: politics
-    weight: 3
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-  - name: adult_content
-    weight: 50
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+  - name: arxiv
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_code/aggressive.yaml
+++ b/configs/experiments/quality_upsampling/heavy_code/aggressive.yaml
@@ -10,132 +10,137 @@
 
 name: quality-upsampling-aggressive-heavy-code
 description: Quality upsampling experiment - aggressive weighting with heavy code mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 98
-  topics:
-  - name: science_math_and_technology
-    weight: 20
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-  - name: software_development
-    weight: 50
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-  - name: education_and_jobs
-    weight: 15
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-  - name: politics
-    weight: 5
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-  - name: adult_content
-    weight: 3
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 98
+    topics:
+    - name: science_math_and_technology
+      weight: 20
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+    - name: software_development
+      weight: 50
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+  - name: arxiv
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_code/gradual.yaml
+++ b/configs/experiments/quality_upsampling/heavy_code/gradual.yaml
@@ -10,150 +10,155 @@
 
 name: quality-upsampling-gradual-heavy-code
 description: Quality upsampling experiment - gradual weighting with heavy code mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 98
-  topics:
-  - name: science_math_and_technology
-    weight: 20
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: med
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 98
+    topics:
+    - name: science_math_and_technology
       weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-  - name: software_development
-    weight: 50
-    quality:
-    - name: best
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+    - name: software_development
       weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-  - name: education_and_jobs
-    weight: 15
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-  - name: politics
-    weight: 5
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-  - name: adult_content
-    weight: 3
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+  - name: arxiv
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_science/aggressive.yaml
+++ b/configs/experiments/quality_upsampling/heavy_science/aggressive.yaml
@@ -10,132 +10,137 @@
 
 name: quality-upsampling-aggressive-heavy-science
 description: Quality upsampling experiment - aggressive weighting with heavy science mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 98
-  topics:
-  - name: science_math_and_technology
-    weight: 50
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-  - name: software_development
-    weight: 20
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-  - name: education_and_jobs
-    weight: 15
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-  - name: politics
-    weight: 5
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-  - name: adult_content
-    weight: 3
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 98
+    topics:
+    - name: science_math_and_technology
+      weight: 50
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+  - name: arxiv
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_science/gradual.yaml
+++ b/configs/experiments/quality_upsampling/heavy_science/gradual.yaml
@@ -10,150 +10,155 @@
 
 name: quality-upsampling-gradual-heavy-science
 description: Quality upsampling experiment - gradual weighting with heavy science mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 98
-  topics:
-  - name: science_math_and_technology
-    weight: 50
-    quality:
-    - name: best
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 98
+    topics:
+    - name: science_math_and_technology
       weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: med
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+    - name: software_development
       weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-  - name: software_development
-    weight: 20
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-  - name: education_and_jobs
-    weight: 15
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-  - name: politics
-    weight: 5
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-  - name: adult_content
-    weight: 3
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+    - name: politics
+      weight: 5
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+    - name: adult_content
+      weight: 3
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+  - name: arxiv
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 1
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_wiki/aggressive.yaml
+++ b/configs/experiments/quality_upsampling/heavy_wiki/aggressive.yaml
@@ -10,132 +10,137 @@
 
 name: quality-upsampling-aggressive-heavy-wiki
 description: Quality upsampling experiment - aggressive weighting with heavy wiki mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 69
-  topics:
-  - name: science_math_and_technology
-    weight: 25
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-  - name: software_development
-    weight: 20
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-  - name: education_and_jobs
-    weight: 15
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-  - name: politics
-    weight: 3
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-  - name: adult_content
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 69
+    topics:
+    - name: science_math_and_technology
+      weight: 25
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+    - name: software_development
+      weight: 20
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+    - name: adult_content
+      weight: 1
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: high
+        weight: 70
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: med
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+  - name: arxiv
     weight: 1
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: high
-      weight: 70
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: med
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 30
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 30
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/quality_upsampling/heavy_wiki/gradual.yaml
+++ b/configs/experiments/quality_upsampling/heavy_wiki/gradual.yaml
@@ -10,150 +10,155 @@
 
 name: quality-upsampling-gradual-heavy-wiki
 description: Quality upsampling experiment - gradual weighting with heavy wiki mix
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-chinchilla_multiple: 0.5
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-minimum_weight: 0.0001
-sources:
-- name: all_dressed
-  weight: 69
-  topics:
-  - name: science_math_and_technology
-    weight: 25
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
-    - name: med
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
+  - name: all_dressed
+    weight: 69
+    topics:
+    - name: science_math_and_technology
+      weight: 25
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
+    - name: software_development
       weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/science_math_and_technology/vigintile_0015/*.npy
-  - name: software_development
-    weight: 20
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
-  - name: education_and_jobs
-    weight: 15
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
-  - name: politics
-    weight: 3
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
-  - name: adult_content
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/software_development/vigintile_0015/*.npy
+    - name: education_and_jobs
+      weight: 15
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/education_and_jobs/vigintile_0015/*.npy
+    - name: politics
+      weight: 3
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/politics/vigintile_0015/*.npy
+    - name: adult_content
+      weight: 1
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
+    - name: art_and_design
+      weight: 5
+      quality:
+      - name: best
+        weight: 50
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
+      - name: high
+        weight: 30
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
+      - name: med
+        weight: 20
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
+      - name: low
+        weight: 0
+        paths:
+        - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
+  - name: arxiv
     weight: 1
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/adult_content/vigintile_0015/*.npy
-  - name: art_and_design
-    weight: 5
-    quality:
-    - name: best
-      weight: 50
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0020/*.npy
-    - name: high
-      weight: 30
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0018/*.npy
-    - name: med
-      weight: 20
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0017/*.npy
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0016/*.npy
-    - name: low
-      weight: 0
-      paths:
-      - s3://ai2-llm/preprocessed/cc_all_dressed/all_dressed_v3/dclm_plus2_vigilantes/allenai/dolma2-tokenizer/art_and_design/vigintile_0015/*.npy
-- name: arxiv
-  weight: 1
-  paths:
-  - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 1.5
-- name: wikipedia
-  weight: 30
-  paths:
-  - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
-  max_repetition_factor: 2.0
+    paths:
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 1.5
+  - name: wikipedia
+    weight: 30
+    paths:
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
+    max_repetition_factor: 2.0
+swarm:
+  seed: 42
+  variants: 1
+  minimum_weight: 0.0001

--- a/configs/experiments/training_duration/duration_0.5x.yaml
+++ b/configs/experiments/training_duration/duration_0.5x.yaml
@@ -8,44 +8,41 @@
 
 name: duration-0.5x
 description: Training duration experiment - 0.5x Chinchilla (140M tokens)
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings - use 14M model for fast tests
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 0.5  # 0.5 * 20 * 14M = 140M tokens
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Data sources - balanced mix across 5 domains
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: dclm
     max_repetition_factor: 1.0
     topics:
-      - name: science_math_and_technology
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy"
-      - name: software_development
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy"
-      - name: education_and_jobs
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy"
-
+    - name: science_math_and_technology
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy
+    - name: software_development
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy
+    - name: education_and_jobs
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy
   - name: wikipedia
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
-
   - name: arxiv
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
+swarm:
+  seed: 42
+  variants: 1

--- a/configs/experiments/training_duration/duration_2.5x.yaml
+++ b/configs/experiments/training_duration/duration_2.5x.yaml
@@ -8,44 +8,41 @@
 
 name: duration-2.5x
 description: Training duration experiment - 2.5x Chinchilla (700M tokens)
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings - use 14M model for fast tests
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 2.5  # 2.5 * 20 * 14M = 700M tokens
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Data sources - balanced mix across 5 domains
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 2.5
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: dclm
     max_repetition_factor: 1.0
     topics:
-      - name: science_math_and_technology
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy"
-      - name: software_development
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy"
-      - name: education_and_jobs
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy"
-
+    - name: science_math_and_technology
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy
+    - name: software_development
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy
+    - name: education_and_jobs
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy
   - name: wikipedia
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
-
   - name: arxiv
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
+swarm:
+  seed: 42
+  variants: 1

--- a/configs/experiments/training_duration/duration_5.0x.yaml
+++ b/configs/experiments/training_duration/duration_5.0x.yaml
@@ -8,44 +8,41 @@
 
 name: duration-5.0x
 description: Training duration experiment - 5.0x Chinchilla (1.4B tokens)
-budget: ai2/oe-base
-workspace: ai2/oe-data
-cluster: ai2/jupiter
-priority: high
-
-# Model settings - use 14M model for fast tests
-proxy_model_id: olmo3_14m
-tokenizer: dolma2
-
-# Training settings
-chinchilla_multiple: 5.0  # 5.0 * 20 * 14M = 1.4B tokens
-nodes: 1
-gpus: 1
-global_batch_size: 16
-variants: 1
-seed: 42
-
-# Data sources - balanced mix across 5 domains
-sources:
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 5.0
+  seed: 42
+  global_batch_size: 16
+data:
+  sources:
   - name: dclm
     max_repetition_factor: 1.0
     topics:
-      - name: science_math_and_technology
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy"
-      - name: software_development
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy"
-      - name: education_and_jobs
-        paths:
-          - "s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy"
-
+    - name: science_math_and_technology
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/science_math_and_technology/**/*.npy
+    - name: software_development
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/software_development/**/*.npy
+    - name: education_and_jobs
+      paths:
+      - s3://ai2-llm/preprocessed/dclm/baseline_topic_ft_lr05_ng2_n3M6_ova_20pct/allenai/dolma2-tokenizer/education_and_jobs/**/*.npy
   - name: wikipedia
     paths:
-      - "s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/wikipedia-dolma-0823/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 2.0
-
   - name: arxiv
     paths:
-      - "s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy"
+    - s3://ai2-llm/preprocessed/proof-pile-2/v0_decontaminated-0625_tokenized/arxiv/train/allenai/dolma2-tokenizer/*.npy
     max_repetition_factor: 1.5
+swarm:
+  seed: 42
+  variants: 1

--- a/olmix/cli.py
+++ b/olmix/cli.py
@@ -260,7 +260,7 @@ def launch_run(config: Path, mixture_file: Path | None, dry_run: bool, no_cache:
         try:
             if dry_run:
                 logger.info("Dry run mode enabled. Running dry-run for each experiment...")
-                torchrun = experiment_config.gpus > 1
+                torchrun = experiment_config.infra.gpus > 1
                 for lc in launch_configs:
                     logger.info(f"Dry run for {lc.name}:")
                     lc.dry_run(torchrun=torchrun)
@@ -277,7 +277,7 @@ def launch_run(config: Path, mixture_file: Path | None, dry_run: bool, no_cache:
                 return
 
             results = []
-            torchrun = experiment_config.gpus > 1
+            torchrun = experiment_config.infra.gpus > 1
             for lc in tqdm(launch_configs, desc="Launching experiments"):
                 results.append(lc.launch(torchrun=torchrun))
 
@@ -325,7 +325,7 @@ def launch_status(config: Path, group_id: str):
     beaker = Beaker.from_env()
     client = JobClient(beaker=beaker)
     exp_config = config_from_path(config)
-    cluster = beaker.cluster.get(exp_config.cluster)
+    cluster = beaker.cluster.get(exp_config.infra.cluster)
     jobs = client.list(cluster=cluster)
 
     statuses = [
@@ -361,7 +361,7 @@ def launch_cancel(config: Path, group_id: str):
     beaker = Beaker.from_env()
     client = JobClient(beaker=beaker)
     exp_config = config_from_path(config)
-    cluster = beaker.cluster.get(exp_config.cluster)
+    cluster = beaker.cluster.get(exp_config.infra.cluster)
     jobs = [
         {"id": job.id, "display_name": job.display_name, "status": job.status}
         for job in client.list(cluster=cluster)

--- a/olmix/fit/core.py
+++ b/olmix/fit/core.py
@@ -78,6 +78,8 @@ def run_fit(
     wandb_api=None,
     workspace: str = "ai2-llm/regmixer",
     requested_tokens: int | None = None,
+    target_tokens: int | None = None,
+    repetition_factor: float = 5.0,
     natural_kl: tuple | None = None,
     test_ratios_path: tuple[str, ...] = (),
     test_metrics_path: tuple[str, ...] = (),
@@ -458,6 +460,8 @@ def run_fit(
             make_worst_mix=make_worst_mix,
             kl_reg=kl_reg,
             requested_tokens=requested_tokens,
+            target_tokens=target_tokens,
+            repetition_factor=repetition_factor,
             manual_kl=natural_kl,
         )
         plot_and_log_weights(

--- a/olmix/fit/loaders.py
+++ b/olmix/fit/loaders.py
@@ -103,13 +103,11 @@ def load_from_wandb(
     else:
         logger.info("No saved priors in metadata, calculating from source files...")
         priors, original_priors = calculate_priors_with_manual(
-            source_configs=launch_config.sources,
-            dtype=launch_config.dtype,
+            source_configs=launch_config.data.sources,
+            dtype=launch_config.data.dtype,
             use_cache=(not no_cache),
-            manual_prior=launch_config.manual_prior if hasattr(launch_config, "manual_prior") else None,
-            fixed_source_weights=launch_config.fixed_source_weights
-            if hasattr(launch_config, "fixed_source_weights")
-            else None,
+            manual_prior=launch_config.swarm.manual_prior,
+            fixed_source_weights=launch_config.swarm.fixed_source_weights,
         )
 
     if fixed_weight_dict is not None:

--- a/olmix/launch/synthesize_mixture.py
+++ b/olmix/launch/synthesize_mixture.py
@@ -486,15 +486,15 @@ def generate_weights_dirichlet(
 def mk_mixtures(
     config: ExperimentConfig, group_uuid: str, use_cache: bool = True
 ) -> tuple[list[dict[str, tuple[float, float]]], dict]:
-    random.seed(config.seed)
-    np.random.seed(config.seed)
+    random.seed(config.swarm.seed)
+    np.random.seed(config.swarm.seed)
 
-    num_samples = config.variants
-    sources = config.sources
-    leaf_dist, available_tokens, leaf_tokens = calculate_priors(sources, config.dtype, use_cache=use_cache)
+    num_samples = config.swarm.variants
+    sources = config.data.sources
+    leaf_dist, available_tokens, leaf_tokens = calculate_priors(sources, config.data.dtype, use_cache=use_cache)
     priors = {"relative_sizes": leaf_dist, "total_tokens": available_tokens, "token_counts": leaf_tokens}
     logger.info(f"Total tokens for config: {available_tokens:,}")
-    logger.info(f"Using seed: {config.seed}")
+    logger.info(f"Using seed: {config.swarm.seed}")
 
     logger.info("Source distribution:")
     logger.info(leaf_dist)
@@ -511,29 +511,30 @@ def mk_mixtures(
     prior_dist = prior_dist / np.sum(prior_dist)
 
     # convert single-level sampling params into topic/source level
+    swarm = config.swarm
     minimum_source_weight = (
-        config.minimum_source_weight
-        if config.minimum_source_weight
-        else config.minimum_weight
-        if config.minimum_weight
+        swarm.minimum_source_weight
+        if swarm.minimum_source_weight
+        else swarm.minimum_weight
+        if swarm.minimum_weight
         else ConfigDefaults.minimum_weight
     )
     minimum_topic_weight = (
-        config.minimum_topic_weight
-        if config.minimum_topic_weight
-        else config.minimum_weight
-        if config.minimum_weight
+        swarm.minimum_topic_weight
+        if swarm.minimum_topic_weight
+        else swarm.minimum_weight
+        if swarm.minimum_weight
         else ConfigDefaults.minimum_weight
     )
 
-    source_mix_temperature = config.source_mix_temperature if config.source_mix_temperature else config.mix_temperature
-    topic_mix_temperature = config.topic_mix_temperature if config.topic_mix_temperature else config.mix_temperature
+    source_mix_temperature = swarm.source_mix_temperature if swarm.source_mix_temperature else swarm.mix_temperature
+    topic_mix_temperature = swarm.topic_mix_temperature if swarm.topic_mix_temperature else swarm.mix_temperature
 
-    min_source_strength = config.min_source_strength if config.min_source_strength else config.min_strength
-    max_source_strength = config.max_source_strength if config.max_source_strength else config.max_strength
+    min_source_strength = swarm.min_source_strength if swarm.min_source_strength else swarm.min_strength
+    max_source_strength = swarm.max_source_strength if swarm.max_source_strength else swarm.max_strength
 
-    min_topic_strength = config.min_topic_strength if config.min_topic_strength else config.min_strength
-    max_topic_strength = config.max_topic_strength if config.max_topic_strength else config.max_strength
+    min_topic_strength = swarm.min_topic_strength if swarm.min_topic_strength else swarm.min_strength
+    max_topic_strength = swarm.max_topic_strength if swarm.max_topic_strength else swarm.max_strength
 
     mixtures = generate_weights_dirichlet(
         sources=sources,
@@ -547,15 +548,15 @@ def mk_mixtures(
         max_source_strength=max_source_strength,
         min_topic_strength=min_topic_strength,
         max_topic_strength=max_topic_strength,
-        allow_repetition=config.allow_repetition,
-        max_tokens=config.get_max_tokens(),
+        allow_repetition=swarm.allow_repetition,
+        max_tokens=config.training.get_max_tokens(),
         available_tokens=available_tokens,
         enable_bound=True,
-        nonzero_weight=config.nonzero_weight,
-        fixed_source_weights=config.fixed_source_weights,
-        manual_prior=config.manual_prior,
-        sample_multiplier=config.sample_multiplier,
-        existing_mix_file=config.existing_mix_file,
+        nonzero_weight=swarm.nonzero_weight,
+        fixed_source_weights=swarm.fixed_source_weights,
+        manual_prior=swarm.manual_prior,
+        sample_multiplier=swarm.sample_multiplier,
+        existing_mix_file=swarm.existing_mix_file,
     )
 
     weight_maps = []

--- a/plans/017_decompose_experiment_config.md
+++ b/plans/017_decompose_experiment_config.md
@@ -1,0 +1,259 @@
+# Decompose `ExperimentConfig` into typed sub-configs
+
+## Context
+
+`ExperimentConfig` in `olmix/aliases.py` is a 54-field god object that mixes unrelated concerns: Beaker infrastructure, OLMo Core training, data sources, mixture sampling, and fit constraints. The user wants clean abstractions so each config type is self-contained and its purpose is immediately obvious.
+
+### The config types after this refactor
+
+1. **`ExperimentConfig`** (YAML) = `InfraConfig` + `TrainingConfig` + `DataConfig` + `SwarmConfig` — governs `olmix launch` and `olmix mix generate`
+2. **`FitConfig`** (CLI dataclass, already exists in `olmix/fit/cli.py`) — governs `olmix fit`. Absorbs constraint parameters that were previously in ExperimentConfig. Rename `config` field to `experiment_config_path`.
+
+Key principle: **`DataConfig` + `TrainingConfig` = everything needed to train an OLMo Core model.** `SwarmConfig` is the outer-loop that samples candidate mixtures. `InfraConfig` is where to run it.
+
+## Design
+
+### `ExperimentConfig` sub-configs (all in `olmix/aliases.py`)
+
+**`InfraConfig`** — Beaker launch infrastructure (10 fields):
+```
+budget, workspace, cluster, priority, preemptible, nodes, gpus, weka, shared_filesystem, wandb_debug
+```
+
+**`TrainingConfig`** — OLMo Core model + training + eval (12 fields):
+```
+proxy_model_id, tokenizer, chinchilla_multiple, seed, device_batch_size, global_batch_size,
+checkpoint_path, train_type, eval_interval, eval_tasks, no_eval, instance_filter
+```
+Includes `get_max_tokens()` method (uses `chinchilla_multiple` + `proxy_model_id`).
+- `seed`: OLMo Core training seed (passed as `-S` to training script). Separate from swarm seed.
+- `instance_filter`: training-time repetitive sequence filtering (OLMo Core behavior).
+
+**`DataConfig`** — data landscape, what data exists and how it's stored (2 fields):
+```
+sources, dtype
+```
+- `sources: list[SourceConfig]` — data sources with paths, topics, quality buckets, max_repetition_factor
+- `dtype: NumpyDatasetDType` — token data format (needed by both training to read data and by priors calculation to count tokens)
+
+Combined with `TrainingConfig`, this is everything OLMo Core needs to train a model.
+
+**`SwarmConfig`** — outer-loop mixture sampling parameters (20 fields):
+```
+seed, variants, mix_temperature, source_mix_temperature, topic_mix_temperature,
+min_strength, max_strength, min_source_strength, max_source_strength,
+min_topic_strength, max_topic_strength, minimum_weight, minimum_source_weight,
+minimum_topic_weight, nonzero_weight, fixed_source_weights, manual_prior,
+manual_topic_prior, allow_repetition, sample_multiplier, existing_mix_file
+```
+- `seed`: Dirichlet sampling seed for `synthesize_mixture.py`. Independent from training seed.
+
+### Composed `ExperimentConfig`
+
+```python
+class ExperimentConfig(BaseModel):
+    name: str
+    description: str = ""
+    infra: InfraConfig
+    training: TrainingConfig
+    data: DataConfig
+    swarm: SwarmConfig
+```
+
+No `model_validator`. No constraint fields — those move to `FitConfig`.
+
+### Constraint parameters move to `FitConfig`
+
+The 4 constraint fields (`target_tokens`, `target_chinchilla_multiple`, `target_model_id`, `repetition_factor`) are exclusively used by `olmix fit`. They become CLI flags on `olmix fit` and fields in `FitConfig`:
+
+| Old (ExperimentConfig YAML) | New (olmix fit CLI flag / FitConfig field) |
+|---|---|
+| `target_tokens` | `--target-tokens` (replaces `--requested-tokens`) |
+| `target_chinchilla_multiple` | `--target-chinchilla-multiple` (new) |
+| `target_model_id` | `--target-model-id` (new) |
+| `repetition_factor` | `--repetition-factor` (new, default 5.0) |
+
+`get_target_tokens()` moves to a standalone helper in `olmix/fit/utils.py`. `compute_constraints_from_config()` takes constraint params directly.
+
+### YAML format (nested)
+
+```yaml
+name: mix-baseline
+description: Data proportions experiment - balanced baseline mix
+
+infra:
+  budget: ai2/oe-base
+  workspace: ai2/oe-data
+  cluster: ai2/jupiter
+  priority: high
+  nodes: 1
+  gpus: 1
+
+training:
+  proxy_model_id: olmo3_14m
+  tokenizer: dolma2
+  chinchilla_multiple: 0.5
+  seed: 42              # OLMo Core training seed
+  global_batch_size: 16
+
+data:
+  dtype: uint32
+  sources:
+    - name: dclm
+      max_repetition_factor: 1.0
+      topics:
+        - name: science_math_and_technology
+          paths: [...]
+    - name: wikipedia
+      paths: [...]
+      max_repetition_factor: 2.0
+
+swarm:
+  seed: 42              # Dirichlet sampling seed
+  variants: 1
+```
+
+### Complete field mapping (all 50 ExperimentConfig fields)
+
+| Field | New location |
+|---|---|
+| `name` | ExperimentConfig (top-level) |
+| `description` | ExperimentConfig (top-level) |
+| `budget` | InfraConfig |
+| `workspace` | InfraConfig |
+| `cluster` | InfraConfig |
+| `priority` | InfraConfig |
+| `preemptible` | InfraConfig |
+| `nodes` | InfraConfig |
+| `gpus` | InfraConfig |
+| `weka` | InfraConfig |
+| `shared_filesystem` | InfraConfig |
+| `wandb_debug` | InfraConfig |
+| `proxy_model_id` | TrainingConfig |
+| `tokenizer` | TrainingConfig |
+| `chinchilla_multiple` | TrainingConfig |
+| `seed` | TrainingConfig (training seed) + SwarmConfig (sampling seed) |
+| `device_batch_size` | TrainingConfig |
+| `global_batch_size` | TrainingConfig |
+| `checkpoint_path` | TrainingConfig |
+| `train_type` | TrainingConfig |
+| `eval_interval` | TrainingConfig |
+| `eval_tasks` | TrainingConfig |
+| `no_eval` | TrainingConfig |
+| `instance_filter` | TrainingConfig |
+| `dtype` | DataConfig |
+| `sources` | DataConfig |
+| `variants` | SwarmConfig |
+| `mix_temperature` | SwarmConfig |
+| `source_mix_temperature` | SwarmConfig |
+| `topic_mix_temperature` | SwarmConfig |
+| `min_strength` | SwarmConfig |
+| `max_strength` | SwarmConfig |
+| `min_source_strength` | SwarmConfig |
+| `max_source_strength` | SwarmConfig |
+| `min_topic_strength` | SwarmConfig |
+| `max_topic_strength` | SwarmConfig |
+| `minimum_weight` | SwarmConfig |
+| `minimum_source_weight` | SwarmConfig |
+| `minimum_topic_weight` | SwarmConfig |
+| `nonzero_weight` | SwarmConfig |
+| `fixed_source_weights` | SwarmConfig |
+| `manual_prior` | SwarmConfig |
+| `manual_topic_prior` | SwarmConfig |
+| `allow_repetition` | SwarmConfig |
+| `sample_multiplier` | SwarmConfig |
+| `existing_mix_file` | SwarmConfig |
+| `target_tokens` | **Removed** → FitConfig CLI `--target-tokens` |
+| `target_chinchilla_multiple` | **Removed** → FitConfig CLI `--target-chinchilla-multiple` |
+| `target_model_id` | **Removed** → FitConfig CLI `--target-model-id` |
+| `repetition_factor` | **Removed** → FitConfig CLI `--repetition-factor` |
+
+### Source/Topic/Quality sub-model fields (unchanged)
+
+These stay on their Pydantic models, nested under `DataConfig.sources`:
+
+| Model | Fields |
+|---|---|
+| `SourceConfig` | `name`, `paths`, `topics`, `quality`, `max_repetition_factor` |
+| `TopicConfig` | `name`, `paths`, `quality`, `max_repetition_factor`, `max_topic_ratio`, `weight` |
+| `QualityConfig` | `name`, `paths`, `weight`, `max_repetition_factor` |
+
+### File changes
+
+| File | Changes |
+|---|---|
+| `olmix/aliases.py` | Define `InfraConfig`, `TrainingConfig`, `DataConfig`, `SwarmConfig`. Remove constraint fields + `get_target_tokens()`. Compose `ExperimentConfig` from 4 sub-configs. |
+| `olmix/launch/beaker.py` | `config.cluster` → `config.infra.cluster`, `config.seed` → `config.training.seed`, `config.dtype` → `config.data.dtype`, etc. (~25 field accesses) |
+| `olmix/launch/synthesize_mixture.py` | `config.sources` → `config.data.sources`, `config.dtype` → `config.data.dtype`, `config.seed` → `config.swarm.seed`, `config.variants` → `config.swarm.variants`, etc. (~22 field accesses) |
+| `olmix/launch/launch_utils.py` | No changes (already takes `list[SourceConfig]` directly) |
+| `olmix/cli.py` | `config.gpus` → `config.infra.gpus`, etc. (~5 field accesses) |
+| `olmix/fit/cli.py` | Add new CLI flags for constraints. Rename `FitConfig.config` → `FitConfig.experiment_config_path`. Update sub-config field accesses. |
+| `olmix/fit/utils.py` | Refactor `compute_constraints_from_config()` to take constraint params directly. Update sub-config field accesses. |
+| `olmix/fit/loaders.py` | Update sub-config field accesses (~6 changes) |
+| `olmix/fit/core.py` | Update sub-config field accesses (~4 changes) |
+| `configs/experiments/**/*.yaml` (31 files) | Convert flat YAML to nested format with `infra:`, `training:`, `data:`, `swarm:` sections |
+| `tests/test_config.py` | Update test fixtures to use nested format |
+
+## Implementation steps
+
+### Step 1: Define sub-config classes in `olmix/aliases.py`
+- Add `InfraConfig`, `TrainingConfig`, `DataConfig`, `SwarmConfig` as Pydantic BaseModel classes
+- Move `get_max_tokens()` to `TrainingConfig`
+- Remove constraint fields + `get_target_tokens()` from ExperimentConfig
+- Compose ExperimentConfig from 4 sub-configs
+
+### Step 2: Convert all 31 YAML configs to nested format
+- Group flat keys under `infra:`, `training:`, `data:`, `swarm:` sections
+- Split `seed` into `training.seed` and `swarm.seed`
+- Move `dtype` and `sources` under `data:`
+- Move sampling params under `swarm:`
+- Remove any constraint fields
+
+### Step 3: Update `olmix/launch/beaker.py`
+- Training fields via `config.training.*`, infra fields via `config.infra.*`, data fields via `config.data.*`
+
+### Step 4: Update `olmix/launch/synthesize_mixture.py`
+- Data fields via `config.data.*`, swarm fields via `config.swarm.*`, `get_max_tokens()` via `config.training.get_max_tokens()`
+
+### Step 5: Update `olmix/cli.py`
+- `config.gpus` → `config.infra.gpus`, etc.
+
+### Step 6: Update `olmix/fit/cli.py`
+- Add CLI flags: `--target-tokens`, `--target-chinchilla-multiple`, `--target-model-id`, `--repetition-factor`
+- Remove `--requested-tokens`
+- Rename `FitConfig.config` → `FitConfig.experiment_config_path`
+- Update sub-config field accesses
+
+### Step 7: Update `olmix/fit/utils.py`
+- Refactor `compute_constraints_from_config()` to take constraint params directly
+- Move `get_target_tokens()` logic to standalone helper
+- Update sub-config field accesses
+
+### Step 8: Update `olmix/fit/loaders.py` and `olmix/fit/core.py`
+- Update sub-config field accesses
+
+### Step 9: Update tests
+- Update `tests/test_config.py` fixtures to use nested format
+- Run full test suite
+
+## Verification
+
+1. `python -c "from olmix.aliases import ExperimentConfig, InfraConfig, TrainingConfig, DataConfig, SwarmConfig"` — imports work
+2. `python -c "import yaml; from olmix.aliases import ExperimentConfig; ExperimentConfig(**yaml.safe_load(open('configs/experiments/data_proportions/mix_baseline.yaml')))"` — nested YAML loading works
+3. `python -m pytest tests/ -x -q` — all existing tests pass
+4. `ruff check olmix/ && pyright olmix/` — lint + typecheck pass
+5. `olmix launch run --config configs/experiments/data_proportions/mix_baseline.yaml --dry-run` — dry-run successfully outputs metadata files to `output/mixes/`
+6. Prepare an `olmix launch run --config configs/experiments/data_proportions/mix_baseline.yaml` command for user review (do NOT execute — user will review and launch manually)
+
+## Key files
+
+| File | Role |
+|---|---|
+| `olmix/aliases.py:139-231` | Current ExperimentConfig (primary target) |
+| `olmix/launch/beaker.py:62-183` | Heaviest user of training + infra fields |
+| `olmix/launch/synthesize_mixture.py:486-559` | Heaviest user of data + swarm fields |
+| `olmix/fit/utils.py:67-91` | `compute_constraints_from_config` — constraint logic to refactor |
+| `olmix/fit/cli.py:30-98` | FitConfig dataclass — absorbs constraint fields, rename `config` |
+| `olmix/fit/cli.py:350-593` | `fit()` — loads ExperimentConfig, uses data/swarm fields |
+| `olmix/fit/loaders.py` | `load_from_wandb` — reconstructs ExperimentConfig from JSON |
+| `configs/experiments/**/*.yaml` | 31 YAML files to convert to nested format |


### PR DESCRIPTION
Split the flat 54-field ExperimentConfig into InfraConfig, TrainingConfig, DataConfig, and SwarmConfig. Move constraint fields (target_tokens, target_chinchilla_multiple, target_model_id, repetition_factor) to FitConfig CLI flags. Convert all 31 YAML configs to nested format.